### PR TITLE
Update the createMessageHandler method

### DIFF
--- a/src/lib/reusables/messages.js
+++ b/src/lib/reusables/messages.js
@@ -6,7 +6,7 @@ function createMessageHandler(sourceOrigin, marker, callback) {
     return function (event) {
         if (!sourceOrigin || helpers.normalizeURL(event.origin) === helpers.normalizeURL(sourceOrigin)) {
             var message = event.data;
-            if (message.substr(0, marker.length) === marker) {
+            if (typeof message === 'string' && message.substr(0, marker.length) === marker) {
                 try {
                     message = JSON.parse(message.substring(marker.length));
 


### PR DESCRIPTION
Hi!

I encountered the `Uncaught TypeError: message.substr is not a function` error when used vuejs and the vue devtools chrome extension together.

That happened 'cause the vue devtools chrome extension sends an event, your sdk catches it but the event data includes an object, not a string but the sdk assumes that is a string and tries to use the `substr` method on it.