### PR TITLE
Update requestTokenByPassword with client_secret

### DIFF
--- a/src/lib/api_elements/auth.js
+++ b/src/lib/api_elements/auth.js
@@ -154,6 +154,7 @@ authPrototypeMethods.requestTokenByPassword = function (username, password) {
         },
         body: [
             "client_id=" + this.options.key,
+            "client_secret=" + this.options.client_secret,
             "grant_type=password",
             "username=" + encodeURIComponent(username),
             "password=" + encodeURIComponent(password)


### PR DESCRIPTION
As per [this link](https://developers.egnyte.com/docs/read/Public_API_Authentication#Internal-Applications), applications after January 2015 require a client_secret. The current .requestTokenByPassword method does not handle this value and will fail to return a token.